### PR TITLE
make callback optional to be able to download pdfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@ xero.call('GET', '/Users', null, function(err, json) {
    }
 }
 ```
+
+### Download PDF
+```javascript
+var Xero = require('xero');
+var fs = require('fs');
+
+var xero = new Xero(CONSUMER_KEY, CONSUMER_SECRET, RSA_PRIVATE_KEY);
+var invoiceId = 'invoice-identifier';
+var req = xero.call('GET', '/Invoices/' + invoiceId);
+
+req.setHeader('Accept', 'application/pdf');
+req.on('response', function(response) {
+  var file = fs.createWriteStream(invoiceId + '.pdf');
+  response.pipe(file);
+});
+req.end();
+```
+
 ## Docs
 http://developer.xero.com/api/
 

--- a/index.js
+++ b/index.js
@@ -27,8 +27,7 @@ Xero.prototype.call = function(method, path, body, callback) {
     if (method && method !== 'GET' && body) {
         xml = easyxml.render(body);
     }
-
-    self.oa._performSecureRequest(self.key, self.secret, method, XERO_API_URL + path, null, xml, 'application/xml', function(err, xml, res) {
+    var process = function(err, xml, res) {
         if (err) {
             return callback(err);
         }
@@ -41,7 +40,8 @@ Xero.prototype.call = function(method, path, body, callback) {
                 return callback(null, json, res);
             }
         });
-    });
+    };
+    return self.oa._performSecureRequest(self.key, self.secret, method, XERO_API_URL + path, null, xml, 'application/xml', callback ? process : null);
 }
 
 module.exports = Xero;


### PR DESCRIPTION
If we dont provide a callback for `_performSecureRequest` it will return the raw unsent request object: https://github.com/ciaranj/node-oauth/blob/0.9.10/lib/oauth.js#L405-L410

This allows to override such things like the Accept header.

Also added an example to the README.
