### PR TITLE
Allow input customHeaders

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,14 +6,14 @@ var xml2js = require('xml2js');
 var XERO_BASE_URL = 'https://api.xero.com';
 var XERO_API_URL = XERO_BASE_URL + '/api.xro/2.0';
 
-function Xero(key, secret, rsa_key, showXmlAttributes) {
+function Xero(key, secret, rsa_key, showXmlAttributes, customHeaders) {
     this.key = key;
     this.secret = secret;
 
     this.parser = new xml2js.Parser({explicitArray: false, ignoreAttrs: showXmlAttributes !== undefined ? (showXmlAttributes ? false : true) : true, async: true});
     easyxml.configure({rootElement: 'Request', manifest: true});
 
-    this.oa = new oauth.OAuth(null, null, key, secret, '1.0', null, "PLAINTEXT");
+    this.oa = new oauth.OAuth(null, null, key, secret, '1.0', null, "PLAINTEXT", null, customHeaders);
     this.oa._signatureMethod = "RSA-SHA1"
     this.oa._createSignature = function(signatureBase, tokenSecret) {
         return crypto.createSign("RSA-SHA1").update(signatureBase).sign(rsa_key, output_format = "base64");


### PR DESCRIPTION
Usage example:
var xero = new Xero(CONSUMER_KEY, CONSUMER_SECRET, RSA_PRIVATE_KEY, null, {'If-Modified-Since': '2014-07-10T00:00:00'});

GET Invoices ModifiedAfter a UTC timestamp
http://developer.xero.com/documentation/api/invoices/
The ModifiedAfter filter is actually an HTTP header: ‘If-Modified-Since‘. 
A UTC timestamp (yyyy-mm-ddThh:mm:ss) . Only invoices created or modified since this timestamp will be returned e.g. 2009-11-12T00:00:00
