### PR TITLE
Correct the API calls so it supports adding multiple records at once.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,25 @@ xero.call('GET', '/Users', null, function(err, json) {
    }
 }
 ```
+### Example POST Request
+```javascript
+...
+// Adding contact(s)
+var request;
+// Single
+request = {
+    Name: 'Name1'
+};
+// Multiple
+request = [{
+    Name: 'Name1'
+}, {
+    Name: 'Name2'
+}];
+xero.call('POST', '/Contacts?SummarizeErrors=false', request, function(err, json) {
+        ...
+    });
+```
 
 ### Download PDF
 ```javascript

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 var crypto  = require("crypto");
 var oauth   = require("oauth");
-var easyxml = require('easyxml');
+var EasyXml = require('easyxml');
 var xml2js = require('xml2js');
+var inflect = require('inflect');
 
 var XERO_BASE_URL = 'https://api.xero.com';
 var XERO_API_URL = XERO_BASE_URL + '/api.xro/2.0';
@@ -11,7 +12,6 @@ function Xero(key, secret, rsa_key, showXmlAttributes, customHeaders) {
     this.secret = secret;
 
     this.parser = new xml2js.Parser({explicitArray: false, ignoreAttrs: showXmlAttributes !== undefined ? (showXmlAttributes ? false : true) : true, async: true});
-    easyxml.configure({rootElement: 'Request', manifest: true});
 
     this.oa = new oauth.OAuth(null, null, key, secret, '1.0', null, "PLAINTEXT", null, customHeaders);
     this.oa._signatureMethod = "RSA-SHA1"
@@ -29,7 +29,8 @@ Xero.prototype.call = function(method, path, body, callback) {
         if (Buffer.isBuffer(body)) {
             post_body = body;
         } else {
-            post_body = easyxml.render(body);            
+            var root = path.match(/([^\/\?]+)/)[1];
+            post_body = new EasyXml({rootElement: inflect.singularize(root), rootArray: root, manifest: true}).render(body);
             content_type = 'application/xml';
         }
     }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.0.6",
   "dependencies": {
     "oauth": "0.9.12",
-    "easyxml": "0.0.5",
-    "xml2js": "0.4.4"
+    "easyxml": "1.0.0",
+    "xml2js": "0.4.4",
+    "inflect": "0.3.0"
   },
   "description": "Xero.com Node Library",
   "main": "index.js",


### PR DESCRIPTION
The current version adds 'Request' as rootElement, and we can't add for example <Invoices> as rootElement, followed by multiple <Invoice>, as detailed in Xero API docs.

This fixes it being able to send a single object or an array of objects with the properties for the given API call path.