### PR TITLE
Add per-endpoint methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ results
 
 node_modules
 npm-debug.log
+
+test/keys

--- a/README.md
+++ b/README.md
@@ -77,6 +77,54 @@ req.on('response', function(response) {
 req.end();
 ```
 
+### Extra methods and helpers
+```javascript
+var xero = new Xero(CONSUMER_KEY, CONSUMER_SECRET, RSA_PRIVATE_KEY);
+
+// for use in constructing filters
+xero.helpers.dateToXeroDateTimeString(new Date(0)) // => DateTime(1970-1-1)
+```
+
+Each of the resources listed below has a #find and #findOne method accessible via it's named property (e.g. `xero.Invoices`, `xero.BankTransactions` etc) on the Xero instance. E.g.:
+```javascript
+xero.Invoices.find(function(err, data) {
+  // data.Response.Invoices.Invoice => array of invoices
+});
+xero.Invoices.findOne('foobarId', function(err, data) {
+  // data.Response.Invoices.Invoice === foobarId invoice
+});
+```
+The find method also optionally accepts a filter string
+```javascript
+xero.Invoices.find('AmountDue > 1000000000', function(err, data) {
+  // data.Status === OK
+  // data.Response.Invoices === undefined
+});
+```
+- Accounts
+- BankTransactions
+- BankTransfers
+- BrandingThemes
+- Contacts
+- ContactGroups
+- CreditNotes
+- Currencies
+- Employees
+- ExpenseClaims
+- Invoices
+- Items
+- Journals
+- ManualJournals
+- Organisation
+- OverPayments
+- Payments
+- Prepayments
+- Receipts
+- RepeatingInvoices
+- TaxRates
+- TrackingCategories
+- Users
+
 ## Docs
 http://developer.xero.com/api/
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,9 @@ var oauth   = require("oauth");
 var EasyXml = require('easyxml');
 var xml2js = require('xml2js');
 var inflect = require('inflect');
+var addMethods = require('./src/addMethods');
+var helpers = require('./src/helpers');
+var resources = require('./src/resources');
 
 var XERO_BASE_URL = 'https://api.xero.com';
 var XERO_API_URL = XERO_BASE_URL + '/api.xro/2.0';
@@ -18,6 +21,8 @@ function Xero(key, secret, rsa_key, showXmlAttributes, customHeaders) {
     this.oa._createSignature = function(signatureBase, tokenSecret) {
         return crypto.createSign("RSA-SHA1").update(signatureBase).sign(rsa_key, output_format = "base64");
     }
+
+    addMethods(this, resources);
 }
 
 Xero.prototype.call = function(method, path, body, callback) {
@@ -50,5 +55,7 @@ Xero.prototype.call = function(method, path, body, callback) {
     };
     return self.oa._performSecureRequest(self.key, self.secret, method, XERO_API_URL + path, null, post_body, content_type, callback ? process : null);
 }
+
+Xero.prototype.helpers = helpers;
 
 module.exports = Xero;

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "xero",
   "version": "0.0.7",
   "dependencies": {
-    "oauth": "0.9.12",
     "easyxml": "1.0.0",
-    "xml2js": "0.4.4",
-    "inflect": "0.3.0"
+    "inflect": "0.3.0",
+    "lodash": "^3.9.2",
+    "oauth": "0.9.12",
+    "string": "^3.1.1",
+    "xml2js": "0.4.4"
   },
   "description": "Xero.com Node Library",
   "main": "index.js",
@@ -21,9 +23,13 @@
   "author": "thallium205 <https://github.com/thallium205>",
   "license": "MIT",
   "readmeFilename": "README.md",
-  "devDependencies": {},
+  "devDependencies": {
+    "chai": "^2.3.0",
+    "mocha": "^2.2.5"
+  },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha test/methods-test.js",
+    "test-xero-api": "mocha test/xero-api.js"
   },
   "gitHead": "3ceec8036cd7bafb6949a709220aa6f4f367f710"
 }

--- a/src/addMethods.js
+++ b/src/addMethods.js
@@ -36,7 +36,7 @@ function addMethods(Xero, resources) {
   };
 
   resources.forEach(function(resource) {
-    Xero[resource.toLowerCase()] = _.create(methods, {resource: resource});
+    Xero[resource] = _.create(methods, {resource: resource});
   });
 
 }

--- a/src/addMethods.js
+++ b/src/addMethods.js
@@ -1,0 +1,44 @@
+'use strict';
+var _ = require('lodash');
+
+function pathWithId(id, resource) {
+  return '/' + resource + '/' + id;
+}
+
+function addMethods(Xero, resources) {
+
+  var methods = {
+
+    // provide Xero.prototype.call to to any instance
+    _call: Xero.call,
+
+    _withId: function(id, method, callback) {
+      var path = pathWithId(id, this.resource);
+      return Xero.call(method, path, null, callback);
+    },
+
+    findOne: function(id, callback) {
+      return this._withId(id, 'GET', callback);
+    },
+
+    find: function(filter, callback) {
+      var path = '/' + this.resource;
+
+      if (_.isFunction(filter)) {
+        callback = filter;
+      } else {
+        path += '?where=' + encodeURIComponent(filter);
+      }
+
+      return Xero.call('GET', path, null, callback);
+    }
+
+  };
+
+  resources.forEach(function(resource) {
+    Xero[resource.toLowerCase()] = _.create(methods, {resource: resource});
+  });
+
+}
+
+module.exports = addMethods;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,5 @@
 'use strict';
-var S = require('string');
+var str = require('string');
 
 module.exports = {
 
@@ -9,7 +9,7 @@ module.exports = {
       m: date.getUTCMonth() + 1,
       d: date.getUTCDate()
     };
-    return S('DateTime({{y}}-{{m}}-{{d}})').template(dates);
+    return str('DateTime({{y}}-{{m}}-{{d}})').template(dates);
   }
 
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,15 @@
+'use strict';
+var S = require('string');
+
+module.exports = {
+
+  dateToXeroDateTimeString: function(date) {
+    var dates = {
+      y: date.getUTCFullYear(),
+      m: date.getUTCMonth() + 1,
+      d: date.getUTCDate()
+    };
+    return S('DateTime({{y}}-{{m}}-{{d}})').template(dates);
+  }
+
+};

--- a/src/resources.js
+++ b/src/resources.js
@@ -1,0 +1,30 @@
+// Not implemented:
+// Attachments
+// Bank Statements
+// Reports
+
+module.exports = [
+  'Accounts',
+  'BankTransactions',
+  'BankTransfers',
+  'BrandingThemes',
+  'Contacts',
+  'ContactGroups',
+  'CreditNotes',
+  'Currencies',
+  'Employees',
+  'ExpenseClaims',
+  'Invoices',
+  'Items',
+  'Journals',
+  'ManualJournals',
+  'Organisation',
+  'OverPayments',
+  'Payments',
+  'Prepayments',
+  'Receipts',
+  'RepeatingInvoices',
+  'TaxRates',
+  'TrackingCategories',
+  'Users'
+];

--- a/test/methods-test.js
+++ b/test/methods-test.js
@@ -1,0 +1,44 @@
+/*eslint handle-callback-err:0 */
+'use strict';
+
+var assert = require('chai').assert;
+var Xero = require('../index');
+
+Xero.prototype.call = function(method, path, body, callback) {
+  callback(null, {
+    path: 'api' + path,
+    method: method,
+    body: body
+  });
+};
+
+var xero = new Xero();
+
+describe('methods', function() {
+
+  describe('#_withId', function() {
+    it('should execute xero.call with id and method', function(done) {
+      xero.contacts.findOne('foo', function(err, res) {
+        assert.equal(res.path, 'api/Contacts/foo');
+        assert.equal(res.method, 'GET');
+        done();
+      });
+    });
+  });
+
+  describe('#find', function() {
+    it('should optionally accept a plain filter string', function(done) {
+      var filter = 'Date > ' + xero.helpers.dateToXeroDateTimeString(new Date(0));
+      xero.invoices.find(filter, function(err, res) {
+        assert.equal(res.path, 'api/Invoices?where=Date%20%3E%20DateTime(1970-1-1)');
+      });
+      xero.invoices.find(function(err, res) {
+        assert.equal(res.path, 'api/Invoices');
+        assert.equal(res.method, 'GET');
+      });
+      // allow multiple async executions
+      setTimeout(done, 20);
+    });
+  });
+
+});

--- a/test/methods-test.js
+++ b/test/methods-test.js
@@ -18,7 +18,7 @@ describe('methods', function() {
 
   describe('#_withId', function() {
     it('should execute xero.call with id and method', function(done) {
-      xero.contacts.findOne('foo', function(err, res) {
+      xero.Contacts.findOne('foo', function(err, res) {
         assert.equal(res.path, 'api/Contacts/foo');
         assert.equal(res.method, 'GET');
         done();
@@ -29,10 +29,10 @@ describe('methods', function() {
   describe('#find', function() {
     it('should optionally accept a plain filter string', function(done) {
       var filter = 'Date > ' + xero.helpers.dateToXeroDateTimeString(new Date(0));
-      xero.invoices.find(filter, function(err, res) {
+      xero.Invoices.find(filter, function(err, res) {
         assert.equal(res.path, 'api/Invoices?where=Date%20%3E%20DateTime(1970-1-1)');
       });
-      xero.invoices.find(function(err, res) {
+      xero.Invoices.find(function(err, res) {
         assert.equal(res.path, 'api/Invoices');
         assert.equal(res.method, 'GET');
       });

--- a/test/xero-api.js
+++ b/test/xero-api.js
@@ -17,25 +17,25 @@ describe('Xero API calls', function() {
 
   it('#find w/ filter', function(done) {
     var filter = 'Date > ' + xero.helpers.dateToXeroDateTimeString(new Date(0));
-    xero.invoices.find(filter, function(err, data) {
+    xero.Invoices.find(filter, function(err, data) {
       assert.isArray(data.Response.Invoices.Invoice);
       done();
     });
   });
 
   it('#find w/out filter', function(done) {
-    xero.invoices.find(function(err, data) {
+    xero.Invoices.find(function(err, data) {
       assert.isArray(data.Response.Invoices.Invoice);
       done();
     });
   });
 
-  it('All resources', function(done) {
+  it('All resources: #find', function(done) {
 
     var completed = [];
 
     resources.forEach(function(r) {
-      xero[r.toLowerCase()].find(function(err, data) {
+      xero[r].find(function(err, data) {
         completed.push(r);
         assert.equal(data.Response.Status, 'OK');
       });

--- a/test/xero-api.js
+++ b/test/xero-api.js
@@ -1,0 +1,49 @@
+/*eslint handle-callback-err:0 */
+'use strict';
+
+var assert = require('chai').assert;
+var Xero = require('../index');
+
+// keys/index.js
+// export is obj with strings consumer key, consumer secret, RSA private key
+var keys = require('./keys');
+var resources = require('../src/resources');
+
+var xero = new Xero(keys.consumer, keys.secret, keys.rsa);
+
+describe('Xero API calls', function() {
+
+  this.timeout(6000);
+
+  it('#find w/ filter', function(done) {
+    var filter = 'Date > ' + xero.helpers.dateToXeroDateTimeString(new Date(0));
+    xero.invoices.find(filter, function(err, data) {
+      assert.isArray(data.Response.Invoices.Invoice);
+      done();
+    });
+  });
+
+  it('#find w/out filter', function(done) {
+    xero.invoices.find(function(err, data) {
+      assert.isArray(data.Response.Invoices.Invoice);
+      done();
+    });
+  });
+
+  it('All resources', function(done) {
+
+    var completed = [];
+
+    resources.forEach(function(r) {
+      xero[r.toLowerCase()].find(function(err, data) {
+        completed.push(r);
+        assert.equal(data.Response.Status, 'OK');
+      });
+    });
+    setTimeout(function() {
+      assert.equal(completed.length, resources.length);
+      done();
+    }, 3000);
+  });
+
+});


### PR DESCRIPTION
### Endpoint methods
- Have implemented per-endpoint methods:
 - `Xero[endpoint].find`
 - `Xero[endpoint].findOne`

- `find` optionally accepts a plain filter string e.g. `AmountDue > 1000 AND DueDate > DateTime(1970-1-1)` and handles encoding and appending to Xero API path.
- `findOne` accepts a Xero ID e.g. `xero.Invoices.findOne('foobar, callback)` executes `Xero.call` with a path of `/Invoices/foobar`

### Helper methods
- Helper methods can be found on `Xero.helpers`. Have initially implemented `dateToXeroDateTimeString(date)` which accepts a Date object and returns a string as expected by the Xero API e.g. `DateTime(2015-5-26)`

### What is not included
More work is required for conditional endpoint methods i.e. there is no check for whether an endpoint accepts an id in GET requests so all endpoints receive the `findOne` method regardless.

Need to implement `save` method.

### Tests
- `npm test` validates that the methods forward API calls to `Xero.call`
- `npm run test-xero-api` validates method integration with Xero API. Requires keys as outlined in L7-8 of `test/xero-api.js`

Cheers!