### PR TITLE
Allow a user to specify content type for buffers

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ Xero.prototype.call = function(method, path, body, callback) {
     if (method && method !== 'GET' && body) {
         if (Buffer.isBuffer(body)) {
             post_body = body;
+            content_type = body.content_type;
         } else {
             var root = path.match(/([^\/\?]+)/)[1];
             post_body = new EasyXml({rootElement: inflect.singularize(root), rootArray: root, manifest: true}).render(body);


### PR DESCRIPTION
File uploads often don't work to xero if you can't specify a content type for the uploaded file. This allows users to specify a content type on their buffers so uploads will work correctly.