### PR TITLE
Added ability to provide params with GET requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,16 @@ Xero.prototype.call = function(method, path, body, callback) {
             content_type = 'application/xml';
         }
     }
+    else if (method && method == 'GET' && body) {
+        path += "?";
+        var first = true;
+        for (var param in body) {
+            if (!first) path += "&";
+            path += param + "=" + body[param];
+            first=false;
+        }
+        console.log(path);
+    }
     var process = function(err, xml, res) {
         if (err) {
             return callback(err);


### PR DESCRIPTION
Hi @thallium205,

Thanks so much for the xero module, it's been super useful.

I made a minor change (which hopefully you'll think could be a useful addition) so that I can make GET requests and provide params in the place of the body used for POST requests.

An example of this is:
```xero.call('GET', "/Reports/ProfitAndLoss", {fromDate: "2016-02-14", toDate: "2016-02-19"}, function (err, json) {...})```

Let me know what you think.  

Thanks :)