### PR TITLE
Added ability to GET, PUT and POST to the Xero Payroll API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 var Xero = require('xero');
 
 var xero = new Xero(CONSUMER_KEY, CONSUMER_SECRET, RSA_PRIVATE_KEY);
-xero.call('GET', '/Users', null, function(err, json) {
+xero.callAccounting('GET', '/Users', null, function(err, json) {
         if (err) {
             log.error(err);
             return res.json(400, {error: 'Unable to contact Xero'});
@@ -55,7 +55,7 @@ request = [{
 }, {
     Name: 'Name2'
 }];
-xero.call('POST', '/Contacts?SummarizeErrors=false', request, function(err, json) {
+xero.callAccounting('POST', '/Contacts?SummarizeErrors=false', request, function(err, json) {
         ...
     });
 ```
@@ -67,7 +67,7 @@ var fs = require('fs');
 
 var xero = new Xero(CONSUMER_KEY, CONSUMER_SECRET, RSA_PRIVATE_KEY);
 var invoiceId = 'invoice-identifier';
-var req = xero.call('GET', '/Invoices/' + invoiceId);
+var req = xero.callAccounting('GET', '/Invoices/' + invoiceId);
 
 req.setHeader('Accept', 'application/pdf');
 req.on('response', function(response) {
@@ -75,6 +75,21 @@ req.on('response', function(response) {
   response.pipe(file);
 });
 req.end();
+```
+
+### Using Payroll API
+### Request
+```javascript
+var Xero = require('xero');
+
+var xero = new Xero(CONSUMER_KEY, CONSUMER_SECRET, RSA_PRIVATE_KEY);
+xero.callPayroll('GET', '/Users', null, function(err, json) {
+        if (err) {
+            log.error(err);
+            return res.json(400, {error: 'Unable to contact Xero'});
+        }
+        return res.json(200, json);
+    });
 ```
 
 ## Docs

--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ req.end();
 ```
 
 ### Using Payroll API
-### Request
+### Request a list of Timesheets
 ```javascript
 var Xero = require('xero');
 
 var xero = new Xero(CONSUMER_KEY, CONSUMER_SECRET, RSA_PRIVATE_KEY);
-xero.callPayroll('GET', '/Users', null, function(err, json) {
+xero.callPayroll('GET', '/Timesheets', null, function(err, json) {
         if (err) {
             log.error(err);
             return res.json(400, {error: 'Unable to contact Xero'});

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 var Xero = require('xero');
 
 var xero = new Xero(CONSUMER_KEY, CONSUMER_SECRET, RSA_PRIVATE_KEY);
-xero.callAccounting('GET', '/Users', null, function(err, json) {
+xero.call('GET', 'accounting','/Users', null, function(err, json) {
         if (err) {
             log.error(err);
             return res.json(400, {error: 'Unable to contact Xero'});
@@ -55,7 +55,7 @@ request = [{
 }, {
     Name: 'Name2'
 }];
-xero.callAccounting('POST', '/Contacts?SummarizeErrors=false', request, function(err, json) {
+xero.call('POST', 'accounting', '/Contacts?SummarizeErrors=false', request, function(err, json) {
         ...
     });
 ```
@@ -67,7 +67,7 @@ var fs = require('fs');
 
 var xero = new Xero(CONSUMER_KEY, CONSUMER_SECRET, RSA_PRIVATE_KEY);
 var invoiceId = 'invoice-identifier';
-var req = xero.callAccounting('GET', '/Invoices/' + invoiceId);
+var req = xero.call('GET', 'accounting', '/Invoices/' + invoiceId);
 
 req.setHeader('Accept', 'application/pdf');
 req.on('response', function(response) {
@@ -83,7 +83,7 @@ req.end();
 var Xero = require('xero');
 
 var xero = new Xero(CONSUMER_KEY, CONSUMER_SECRET, RSA_PRIVATE_KEY);
-xero.callPayroll('GET', '/Timesheets', null, function(err, json) {
+xero.call('GET', 'payroll', '/Timesheets', null, function(err, json) {
         if (err) {
             log.error(err);
             return res.json(400, {error: 'Unable to contact Xero'});
@@ -91,6 +91,13 @@ xero.callPayroll('GET', '/Timesheets', null, function(err, json) {
         return res.json(200, json);
     });
 ```
+
+### Using Other APIs
+### Assets API
+`xero.call('GET', 'assets', ...`
+### Files API
+`xero.call('GET', 'files', ...`
+
 
 ## Docs
 http://developer.xero.com/api/

--- a/README.md
+++ b/README.md
@@ -102,4 +102,3 @@ xero.call('GET', 'payroll', '/Timesheets', null, function(err, json) {
 ## Docs
 http://developer.xero.com/api/
 
-Enjoy! - thallium205 <https://github.com/thallium205>

--- a/index.js
+++ b/index.js
@@ -48,7 +48,12 @@ Xero.prototype.call = function(method, endpoint, path, body, callback) {
             post_body = body;
         } else {
             var root = path.match(/([^\/\?]+)/)[1];
-            post_body = new EasyXml({rootElement: inflect.singularize(root), rootArray: root, manifest: true}).render(body);
+
+            if (path.search('PayItems') !== -1) {
+                post_body = new EasyXml({rootElement: root, rootArray: root, manifest: true}).render(body);
+            } else {
+                post_body = new EasyXml({rootElement: inflect.singularize(root), rootArray: root, manifest: true}).render(body);
+            }
             content_type = 'application/xml';
         }
     }

--- a/index.js
+++ b/index.js
@@ -22,9 +22,25 @@ function Xero(key, secret, rsa_key, showXmlAttributes, customHeaders) {
     }
 }
 
-Xero.prototype.call = function(method, path, body, callback) {
+Xero.prototype.call = function(method, endpoint, path, body, callback) {
     var self = this;
-
+    switch (endpoint) {
+        case 'accounting':
+            endpoint = '/api.xro/2.0';
+            break;
+        case 'payroll':
+            endpoint = '/payroll.xro/1.0';
+            break;
+        case 'assets':
+            endpoint = '/assets.xro/1.0';
+            break;
+        case 'files':
+            endpoint = '/files.xro/1.0';
+            break;
+        default:
+            endpoint = '/api.xro/2.0';
+    }
+    XERO_API_URL = XERO_BASE_URL + endpoint;
     var post_body = null;
     var content_type = null;
     if (method && method !== 'GET' && body) {
@@ -51,15 +67,6 @@ Xero.prototype.call = function(method, path, body, callback) {
         });
     };
     return self.oa._performSecureRequest(self.key, self.secret, method, XERO_API_URL + path, null, post_body, content_type, callback ? process : null);
-}
-
-Xero.prototype.callPayroll    = function (method, path, body, callback) {
-    XERO_API_URL = XERO_BASE_URL + '/payroll.xro/1.0';
-    Xero.prototype.call.call(this, method, path, body, callback);
-}
-Xero.prototype.callAccounting = function (method, path, body, callback) {
-    XERO_API_URL = XERO_BASE_URL + '/api.xro/2.0';
-    Xero.prototype.call.call(this, method, path, body, callback);
 }
 
 module.exports = Xero;

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ var xml2js = require('xml2js');
 var inflect = require('inflect');
 
 var XERO_BASE_URL = 'https://api.xero.com';
+
+// Set the default Xero Api URL to be the accounting API URL
 var XERO_API_URL = XERO_BASE_URL + '/api.xro/2.0';
 
 function Xero(key, secret, rsa_key, showXmlAttributes, customHeaders) {
@@ -49,6 +51,15 @@ Xero.prototype.call = function(method, path, body, callback) {
         });
     };
     return self.oa._performSecureRequest(self.key, self.secret, method, XERO_API_URL + path, null, post_body, content_type, callback ? process : null);
+}
+
+Xero.prototype.callPayroll    = function (method, path, body, callback) {
+    XERO_API_URL = XERO_BASE_URL + '/payroll.xro/1.0';
+    Xero.prototype.call.call(this, method, path, body, callback);
+}
+Xero.prototype.callAccounting = function (method, path, body, callback) {
+    XERO_API_URL = XERO_BASE_URL + '/api.xro/2.0';
+    Xero.prototype.call.call(this, method, path, body, callback);
 }
 
 module.exports = Xero;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xero-private",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "dependencies": {
     "oauth": "0.9.12",
     "easyxml": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,23 +7,23 @@
     "xml2js": "0.4.4",
     "inflect": "0.3.0"
   },
-  "description": "Xero.com Node Library",
+  "description": "Xero.com Node Library for private applications",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git@github.com:thallium205/xero.git"
+    "url": "git@github.com:gazzenger/xero.git"
   },
   "keywords": [
     "xero",
     "node",
     "nodejs"
   ],
-  "author": "thallium205 <https://github.com/thallium205>",
+  "author": "gazzenger <https://github.com/gazzenger>",
   "license": "MIT",
   "readmeFilename": "README.md",
   "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "gitHead": "3ceec8036cd7bafb6949a709220aa6f4f367f710"
+  "gitHead": "68b5de2e176c1282d242b5348e2ea3124c14b03b"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xero",
+  "name": "xero-private",
   "version": "0.0.8",
   "dependencies": {
     "oauth": "0.9.12",
@@ -11,7 +11,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git@github.com:gazzenger/xero.git"
+    "url": "git@github.com:gazzenger/xero-private.git"
   },
   "keywords": [
     "xero",
@@ -25,5 +25,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "gitHead": "68b5de2e176c1282d242b5348e2ea3124c14b03b"
+  "bugs": {
+    "url": "https://github.com/gazzenger/xero/issues"
+  },
+  "homepage": "https://github.com/gazzenger/xero#readme"
 }


### PR DESCRIPTION
Thanks so much for this fantastic module.

I made a minor change so that a user can now also perform GET, POST and PUT commands to the Payroll API on Xero. This means users can now handle timesheets, payitems as well as many other features.

I've left support for the command xero.call, however I've added the following commands,
xero.callAccounting() and
xero.callPayroll()

These commands work the same way as xero.call, but allow distinguishing between Accounting API (which is what the current code does), and the Payroll API.

An example to get a list of timesheets would be,
xero.callPayroll('GET', "/Timesheets", null, function (err, json) {...})

Let me know your thoughts on the additions,

Kind Regards,
Gary
